### PR TITLE
docs: update connector description

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Set up an Expensify connector"
 og:title: "Set up an Expensify connector"
-description: "C1 provides identity governance and just-in-time provisioning for Expensify. Integrate your Expensify instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
-og:description: "C1 provides identity governance and just-in-time provisioning for Expensify. Integrate your Expensify instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
+description: "C1 provides identity governance for Expensify. Integrate your Expensify instance with C1 for unified visibility and governance over user access."
+og:description: "C1 provides identity governance for Expensify. Integrate your Expensify instance with C1 for unified visibility and governance over user access."
 sidebarTitle: "Expensify"
 ---
 
@@ -30,7 +30,7 @@ A user with access to the Expensify Integration Server must perform this task.
   </Step>
 </Steps>
 
-**That's it!** Next, move on to the connector configuration instructions.
+**Done.** Next, move on to the connector configuration instructions.
 
 ## Configure the Expensify connector
 
@@ -83,7 +83,7 @@ To complete this task, you'll need:
   </Step>
 </Steps>
 
-**That's it!** Your Expensify connector is now pulling access data into C1.
+**Done.** Your Expensify connector is now pulling access data into C1.
 
 </Tab>
 <Tab title="Self-hosted">
@@ -197,7 +197,7 @@ spec:
   </Step>
 </Steps>
 
-**That's it!** Your Expensify connector is now pulling access data into C1.
+**Done.** Your Expensify connector is now pulling access data into C1.
 
 </Tab>
 </Tabs>


### PR DESCRIPTION
Replicates changes from [ConductorOne/docs#221](https://github.com/ConductorOne/docs/pull/221).

- Removes inaccurate provisioning claims from the connector description
- Updates `**That's it!**` to `**Done.**` to align with brand voice guidelines